### PR TITLE
Fix a bug where this.time was negative

### DIFF
--- a/src/audio-listener.ts
+++ b/src/audio-listener.ts
@@ -1,6 +1,8 @@
 import {Component} from '@wonderlandengine/api';
 
 const SAMPLE_RATE = 48000;
+/* 5ms for now, so it definitely takes less than one frame */
+const FADE_DURATION = 5 / 1000;
 const tempVec: Float32Array = new Float32Array(3);
 const tempVec2: Float32Array = new Float32Array(3);
 export const audioBuffers: {[key: string]: Promise<AudioBuffer>} = {};
@@ -73,8 +75,8 @@ export class AudioListener extends Component {
             -tempVec2[1]
         );
     }
-    _updateRecommended(dt: number) {
-        this.time = _audioContext.currentTime + dt;
+    _updateRecommended() {
+        this.time = _audioContext.currentTime + FADE_DURATION;
         /* Set the position of the listener */
         this.object.getPositionWorld(tempVec);
         this.listener.positionX.linearRampToValueAtTime(tempVec[0], this.time);


### PR DESCRIPTION
This is a fix based on a bug that Timmy reported. Somehow, `this.time` was negative, which resulted in `linearRamp` function to fail. The Bug is not reproducible, therefore this fix is more of a guess of what could have happened:  

`audioContext.currentTime` starts a 0, so the only possible way of `this.time` becoming negative, is that dt is negative.

Hence, making dt a constant, should fix this error.