### PR TITLE
source: Add rawbuffer param to play()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {AudioSource} from './audio-source.js';
+export {AudioSource, loadAudio} from './audio-source.js';
 export {AudioListener} from './audio-listener.js';
 export * from './audio-manager.js';


### PR DESCRIPTION
- adds export of internal `loadAudio` function
- makes `play()` function accept a external buffer as parameter